### PR TITLE
add support for registering and unregistering android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sample API Calls
 
 1. Register a device
 
-	ua.registerDevice("< token >", function(error) {...});
+	ua.registerDevice(["ios"|"android"], < token >", function(error) {...});
 
 2. Create payloads for the push notification API needed.
 
@@ -59,7 +59,7 @@ Sample API Calls
 
 3. Unregister a device.
 
-	ua.unregisterDevice("< token >", function(error) {....});
+	ua.unregisterDevice(["ios"|"android"], "< token >", function(error) {....});
 
 
 

--- a/lib/urban-airship.js
+++ b/lib/urban-airship.js
@@ -19,7 +19,7 @@ var UrbanAirship = function(key, secret, master) {
 	this._key = key;
 	this._secret = secret;
 	this._master = master;
-}
+};
 
 
 /**
@@ -47,7 +47,7 @@ UrbanAirship.prototype.getDeviceTokenCounts = function(callback) {
 UrbanAirship.prototype.pushNotification = function(path, payload, callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	this._transport(path, "POST", payload, callback);
-}
+};
 
 
 /*
@@ -58,10 +58,11 @@ UrbanAirship.prototype.pushNotification = function(path, payload, callback) {
  *	data - The JSON payload (optional)
  *	callback
  */
-UrbanAirship.prototype.registerDevice = function(device_id, data, callback) {
+UrbanAirship.prototype.registerDevice = function(device_type, device_id, data, callback) {
 	this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
-		
-	var path = "/api/device_tokens/" + device_id;
+
+    var path_type = device_type === 'android' ? 'apids' : 'device_tokens';
+    var path = "/api/"+path_type+"/" + device_id;
 	
 	if (data) {
 		// Registration with optional data
@@ -71,7 +72,7 @@ UrbanAirship.prototype.registerDevice = function(device_id, data, callback) {
 		// Simple registration with no additional data
 		this._transport(path, "PUT", callback);
 	}
-}
+};
 
 /*
  * Unregister a device.
@@ -80,10 +81,13 @@ UrbanAirship.prototype.registerDevice = function(device_id, data, callback) {
  *	device_id - The device identifier
  *	callback
  */
-UrbanAirship.prototype.unregisterDevice = function(device_id, callback) {
+UrbanAirship.prototype.unregisterDevice = function(device_type, device_id, callback) {
+
+    var path_type = device_type === 'android' ? 'apids' : 'device_tokens';
+
 	this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
-	this._transport("/api/device_tokens/" + device_id, "DELETE", callback);
-}
+	this._transport("/api/"+path_type+"/" + device_id, "DELETE", callback);
+};
 
 /*
  * Send things to UA!


### PR DESCRIPTION
- By adding the device_type parameter to the registerDevice and
  unregisterDevice methods, it is now possible to register and unregister
  Android devices. This has to be better handled to also support Windows
  and BlackBerry.
- Updated readme.
- Plus, fixed semicolons at the end of some methods declarations ;)
