### PR TITLE
Enable registration and unregistration of different types of devices

### DIFF
--- a/lib/urban-airship.js
+++ b/lib/urban-airship.js
@@ -51,6 +51,26 @@ UrbanAirship.prototype.pushNotification = function(path, payload, callback) {
 
 
 /*
+ * Get the endpoint for a device token
+ *
+ * @params
+ *   device_id – The device identifier
+ * @return string
+ */
+UrbanAirship.device_endpoint = function(device_id) {
+    switch (device_id.length) {
+        case 64:
+            return 'device_tokens';
+        case 36:
+            return'apids';
+        case 8:
+            return 'device_pins';
+        default:
+            return false;
+    }
+};
+
+/*
  * Register a new device.
  *
  * @params
@@ -59,18 +79,17 @@ UrbanAirship.prototype.pushNotification = function(path, payload, callback) {
  *	callback
  */
 UrbanAirship.prototype.registerDevice = function(device_id, data, callback) {
-	this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
-		
-	var path = "/api/device_tokens/" + device_id;
-	
-	if (data) {
-		// Registration with optional data
-		this._transport(path, "PUT", data, callback);
-	}
-	else {
-		// Simple registration with no additional data
-		this._transport(path, "PUT", callback);
-	}
+    this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
+
+    var path = "/api/"+UrbanAirship.device_endpoint(device_id)+"/" + device_id;
+
+    if (data) {
+        // Registration with optional data
+        this._transport(path, "PUT", data, callback);
+    } else {
+        // Simple registration with no additional data
+        this._transport(path, "PUT", callback);
+    }
 }
 
 /*
@@ -81,10 +100,10 @@ UrbanAirship.prototype.registerDevice = function(device_id, data, callback) {
  *	callback
  */
 UrbanAirship.prototype.unregisterDevice = function(device_id, callback) {
-	this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
-	this._transport("/api/device_tokens/" + device_id, "DELETE", callback);
+    this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
+    var path = "/api/"+UrbanAirship.device_endpoint(device_id)+"/" + device_id;
+    this._transport(path, "DELETE", callback);
 }
-
 /*
  * Send things to UA!
  *

--- a/lib/urban-airship.js
+++ b/lib/urban-airship.js
@@ -66,7 +66,7 @@ UrbanAirship.device_endpoint = function(device_id) {
         case 8:
             return 'device_pins';
         default:
-            return false;
+            throw new Error("The device ID was not a valid length ID");
     }
 };
 


### PR DESCRIPTION
Fixes #6 
Now supporting android, windows phone (both use `apids`), and blackberry.
