### PR TITLE
adding new urban airship APIs

### DIFF
--- a/lib/urban-airship.js
+++ b/lib/urban-airship.js
@@ -15,7 +15,7 @@ var https = require("https");
  * @param {String} secret Urban Airship secret key
  * @param {String} master Urban Airship master secret
  */
-var UrbanAirship = function (key, secret, master) {
+var UrbanAirship = function(key, secret, master) {
 	this._key = key;
 	this._secret = secret;
 	this._master = master;
@@ -26,7 +26,7 @@ var UrbanAirship = function (key, secret, master) {
  *
  */
 
-UrbanAirship.prototype.getSegments = function (callback) {
+UrbanAirship.prototype.getSegments = function(callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	this._transport('/api/segments/', "GET", null, false, callback);
 }
@@ -39,7 +39,7 @@ UrbanAirship.prototype.getSegments = function (callback) {
  *	callback
  */
 
-UrbanAirship.prototype.addSegment = function (payload, callback) {
+UrbanAirship.prototype.addSegment = function(payload, callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	this._transport('/api/segments/', "POST", payload, true, callback);
 }
@@ -51,7 +51,7 @@ UrbanAirship.prototype.addSegment = function (payload, callback) {
  *	callback
  */
 
-UrbanAirship.prototype.getTags = function (callback) {
+UrbanAirship.prototype.getTags = function(callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	this._transport('/api/tags/', "GET", null, true, callback);
 }
@@ -64,7 +64,7 @@ UrbanAirship.prototype.getTags = function (callback) {
  *	callback
  */
 
-UrbanAirship.prototype.addTag = function (tag, callback) {
+UrbanAirship.prototype.addTag = function(tag, callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	this._transport('/api/tags/' + tag, "PUT", null, true, callback);
 }
@@ -77,7 +77,7 @@ UrbanAirship.prototype.addTag = function (tag, callback) {
  *	callback
  */
 
-UrbanAirship.prototype.addTagToDevices = function (tag, tokensArray, callback) {
+UrbanAirship.prototype.addTagToDevices = function(tag, tokensArray, callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	var payload = {
 		"device_tokens": {
@@ -96,7 +96,7 @@ UrbanAirship.prototype.addTagToDevices = function (tag, tokensArray, callback) {
  *	callback
  */
 
-UrbanAirship.prototype.removeTagFromDevices = function (tag, tokensArray, callback) {
+UrbanAirship.prototype.removeTagFromDevices = function(tag, tokensArray, callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	var payload = {
 		"device_tokens": {
@@ -115,7 +115,7 @@ UrbanAirship.prototype.removeTagFromDevices = function (tag, tokensArray, callba
  *	callback
  */
 
-UrbanAirship.prototype.updateDevicesTags = function (device_id, tags, callback) {
+UrbanAirship.prototype.updateDevicesTags = function(device_id, tags, callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	var payload = {
 		"tags": tags
@@ -130,10 +130,10 @@ UrbanAirship.prototype.updateDevicesTags = function (device_id, tags, callback) 
  *
  * @params callback(error, total, active)
  */
-UrbanAirship.prototype.getDeviceTokenCounts = function (callback) {
+UrbanAirship.prototype.getDeviceTokenCounts = function(callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 
-	this._transport("/api/device_tokens/count/", "GET", true, function (error, response_data) {
+	this._transport("/api/device_tokens/count/", "GET", true, function(error, response_data) {
 		callback(error, response_data.device_tokens_count || 0, response_data.active_device_tokens_count || 0);
 	});
 }
@@ -146,7 +146,7 @@ UrbanAirship.prototype.getDeviceTokenCounts = function (callback) {
  *	payload the object being sent to Urban Airship as specified http://urbanairship.com/docs/push.html
  *	callback
  */
-UrbanAirship.prototype.pushNotification = function (path, payload, callback) {
+UrbanAirship.prototype.pushNotification = function(path, payload, callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
 	this._transport(path, "POST", payload, true, callback);
 }
@@ -158,16 +158,16 @@ UrbanAirship.prototype.pushNotification = function (path, payload, callback) {
  *   device_id – The device identifier
  * @return string
  */
-UrbanAirship.device_endpoint = function (device_id) {
+UrbanAirship.device_endpoint = function(device_id) {
 	switch (device_id.length) {
-	case 64:
-		return 'device_tokens';
-	case 36:
-		return 'apids';
-	case 8:
-		return 'device_pins';
-	default:
-		throw new Error("The device ID was not a valid length ID");
+		case 64:
+			return 'device_tokens';
+		case 36:
+			return 'apids';
+		case 8:
+			return 'device_pins';
+		default:
+			throw new Error("The device ID was not a valid length ID");
 	}
 };
 
@@ -179,7 +179,7 @@ UrbanAirship.device_endpoint = function (device_id) {
  *	data - The JSON payload (optional)
  *	callback
  */
-UrbanAirship.prototype.registerDevice = function (device_id, data, callback) {
+UrbanAirship.prototype.registerDevice = function(device_id, data, callback) {
 	this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
 
 	var path = "/api/" + UrbanAirship.device_endpoint(device_id) + "/" + device_id;
@@ -200,7 +200,7 @@ UrbanAirship.prototype.registerDevice = function (device_id, data, callback) {
  *	device_id - The device identifier
  *	callback
  */
-UrbanAirship.prototype.unregisterDevice = function (device_id, callback) {
+UrbanAirship.prototype.unregisterDevice = function(device_id, callback) {
 	this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
 	var path = "/api/" + UrbanAirship.device_endpoint(device_id) + "/" + device_id;
 	this._transport(path, "DELETE", null, true, callback);
@@ -215,7 +215,7 @@ UrbanAirship.prototype.unregisterDevice = function (device_id, callback) {
  *	request_data - The JSON data we are sending (optional)
  *	callback
  */
-UrbanAirship.prototype._transport = function (path, method, request_data, needAcceptHeader, callback) {
+UrbanAirship.prototype._transport = function(path, method, request_data, needAcceptHeader, callback) {
 	var self = this,
 		rd = "",
 		response_data = "",
@@ -250,14 +250,14 @@ UrbanAirship.prototype._transport = function (path, method, request_data, needAc
 		https_opts.headers["Content-Length"] = 0;
 	}
 
-	var request = https.request(https_opts, function (response) {
+	var request = https.request(https_opts, function(response) {
 		response.setEncoding("utf8");
 
-		response.on("data", function (chunk) {
+		response.on("data", function(chunk) {
 			response_data += chunk;
 		});
 
-		response.on("end", function () {
+		response.on("end", function() {
 			// You probably forget the trailing '/'
 			if ((response.statusCode == 301 || response.statusCode == 302) && response.headers && response.headers.location) {
 				var url = require("url"),
@@ -269,11 +269,11 @@ UrbanAirship.prototype._transport = function (path, method, request_data, needAc
 			else if ([200, 201, 202, 204].indexOf(response.statusCode) >= 0) {
 				try {
 					switch (true) {
-					case /application\/json/.test(response.headers["content-type"]):
-						callback(null, JSON.parse(response_data));
-						break;
-					default:
-						callback(null, response_data);
+						case /application\/json/.test(response.headers["content-type"]):
+							callback(null, JSON.parse(response_data));
+							break;
+						default:
+							callback(null, response_data);
 					}
 				} catch (ex) {
 					callback(ex);
@@ -283,12 +283,12 @@ UrbanAirship.prototype._transport = function (path, method, request_data, needAc
 			}
 		});
 
-		response.on("error", function (error) {
+		response.on("error", function(error) {
 			callback(error);
 		});
 	});
 
-	request.on("error", function (error) {
+	request.on("error", function(error) {
 		callback(error);
 	});
 

--- a/lib/urban-airship.js
+++ b/lib/urban-airship.js
@@ -15,25 +15,128 @@ var https = require("https");
  * @param {String} secret Urban Airship secret key
  * @param {String} master Urban Airship master secret
  */
-var UrbanAirship = function(key, secret, master) {
+var UrbanAirship = function (key, secret, master) {
 	this._key = key;
 	this._secret = secret;
 	this._master = master;
 };
 
 /**
+ * Gets the Segments for this application.
+ *
+ */
+
+UrbanAirship.prototype.getSegments = function (callback) {
+	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
+	this._transport('/api/segments/', "GET", null, false, callback);
+}
+
+/**
+ * Add new segment to this application.
+ *
+ * @params
+ *	payload the object being sent to Urban Airship as specified http://docs.urbanairship.com/reference/api/v3/segments.html
+ *	callback
+ */
+
+UrbanAirship.prototype.addSegment = function (payload, callback) {
+	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
+	this._transport('/api/segments/', "POST", payload, true, callback);
+}
+
+/**
+ * Gets the tags for this application.
+ *
+ * @params
+ *	callback
+ */
+
+UrbanAirship.prototype.getTags = function (callback) {
+	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
+	this._transport('/api/tags/', "GET", null, true, callback);
+}
+
+/**
+ * Add tag for this application.
+ *
+ * @params
+ *	tag to be added.
+ *	callback
+ */
+
+UrbanAirship.prototype.addTag = function (tag, callback) {
+	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
+	this._transport('/api/tags/' + tag, "PUT", null, true, callback);
+}
+
+/**
+ * Add tag to the list of tokens for this application.
+ *
+ * @params
+ *	tag to be added.
+ *	callback
+ */
+
+UrbanAirship.prototype.addTagToDevices = function (tag, tokensArray, callback) {
+	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
+	var payload = {
+		"device_tokens": {
+			"add": tokensArray
+		}
+	};
+
+	this._transport('/api/tags/' + tag, "POST", payload, true, callback);
+}
+
+/**
+ * remvoe tag from the list of tokens for this application.
+ *
+ * @params
+ *	tag to be added.
+ *	callback
+ */
+
+UrbanAirship.prototype.removeTagFromDevices = function (tag, tokensArray, callback) {
+	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
+	var payload = {
+		"device_tokens": {
+			"remove": tokensArray
+		}
+	};
+
+	this._transport('/api/tags/' + tag, "POST", payload, true, callback);
+}
+
+/**
+ * add/ remove tags for a specific device for this application.
+ *
+ * @params
+ *	tag to be added.
+ *	callback
+ */
+
+UrbanAirship.prototype.updateDevicesTags = function (device_id, tags, callback) {
+	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
+	var payload = {
+		"tags": tags
+	};
+	var path = "/api/" + UrbanAirship.device_endpoint(device_id) + "/" + device_id;
+
+	this._transport(path, "PUT", payload, true, callback);
+}
+
+/**
  * Gets the number of devices tokens authenticated with the application.
  *
  * @params callback(error, total, active)
  */
-UrbanAirship.prototype.getDeviceTokenCounts = function(callback) {
+UrbanAirship.prototype.getDeviceTokenCounts = function (callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
-	
-	this._transport("/api/device_tokens/count/", "GET", function(error, response_data) {
+
+	this._transport("/api/device_tokens/count/", "GET", true, function (error, response_data) {
 		callback(error, response_data.device_tokens_count || 0, response_data.active_device_tokens_count || 0);
 	});
 }
-
 
 /*
  * Push a notification to a registered device.
@@ -43,11 +146,10 @@ UrbanAirship.prototype.getDeviceTokenCounts = function(callback) {
  *	payload the object being sent to Urban Airship as specified http://urbanairship.com/docs/push.html
  *	callback
  */
-UrbanAirship.prototype.pushNotification = function(path, payload, callback) {
+UrbanAirship.prototype.pushNotification = function (path, payload, callback) {
 	this._auth = new Buffer(this._key + ":" + this._master, "utf8").toString("base64");
-	this._transport(path, "POST", payload, callback);
+	this._transport(path, "POST", payload, true, callback);
 }
-
 
 /*
  * Get the endpoint for a device token
@@ -56,17 +158,17 @@ UrbanAirship.prototype.pushNotification = function(path, payload, callback) {
  *   device_id – The device identifier
  * @return string
  */
-UrbanAirship.device_endpoint = function(device_id) {
-    switch (device_id.length) {
-        case 64:
-            return 'device_tokens';
-        case 36:
-            return'apids';
-        case 8:
-            return 'device_pins';
-        default:
-            throw new Error("The device ID was not a valid length ID");
-    }
+UrbanAirship.device_endpoint = function (device_id) {
+	switch (device_id.length) {
+	case 64:
+		return 'device_tokens';
+	case 36:
+		return 'apids';
+	case 8:
+		return 'device_pins';
+	default:
+		throw new Error("The device ID was not a valid length ID");
+	}
 };
 
 /*
@@ -77,18 +179,18 @@ UrbanAirship.device_endpoint = function(device_id) {
  *	data - The JSON payload (optional)
  *	callback
  */
-UrbanAirship.prototype.registerDevice = function(device_id, data, callback) {
-    this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
+UrbanAirship.prototype.registerDevice = function (device_id, data, callback) {
+	this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
 
-    var path = "/api/"+UrbanAirship.device_endpoint(device_id)+"/" + device_id;
+	var path = "/api/" + UrbanAirship.device_endpoint(device_id) + "/" + device_id;
 
-    if (data) {
-        // Registration with optional data
-        this._transport(path, "PUT", data, callback);
-    } else {
-        // Simple registration with no additional data
-        this._transport(path, "PUT", callback);
-    }
+	if (data) {
+		// Registration with optional data
+		this._transport(path, "PUT", data, true, callback);
+	} else {
+		// Simple registration with no additional data
+		this._transport(path, "PUT", null, true, callback);
+	}
 }
 
 /*
@@ -98,11 +200,12 @@ UrbanAirship.prototype.registerDevice = function(device_id, data, callback) {
  *	device_id - The device identifier
  *	callback
  */
-UrbanAirship.prototype.unregisterDevice = function(device_id, callback) {
-    this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
-    var path = "/api/"+UrbanAirship.device_endpoint(device_id)+"/" + device_id;
-    this._transport(path, "DELETE", callback);
+UrbanAirship.prototype.unregisterDevice = function (device_id, callback) {
+	this._auth = new Buffer(this._key + ":" + this._secret, "utf8").toString("base64");
+	var path = "/api/" + UrbanAirship.device_endpoint(device_id) + "/" + device_id;
+	this._transport(path, "DELETE", null, true, callback);
 }
+
 /*
  * Send things to UA!
  *
@@ -112,7 +215,7 @@ UrbanAirship.prototype.unregisterDevice = function(device_id, callback) {
  *	request_data - The JSON data we are sending (optional)
  *	callback
  */
-UrbanAirship.prototype._transport = function(path, method, request_data, callback) {
+UrbanAirship.prototype._transport = function (path, method, request_data, needAcceptHeader, callback) {
 	var self = this,
 		rd = "",
 		response_data = "",
@@ -123,76 +226,76 @@ UrbanAirship.prototype._transport = function(path, method, request_data, callbac
 			"method": method,
 			"headers": {
 				"Authorization": "Basic " + this._auth,
-				"User-Agent": "node-urban-airship/0.3",
-				"Accept": "application/vnd.urbanairship+json; version=3;"
+				"User-Agent": "node-urban-airship/0.3"
 			}
 		};
-	
+
+	if (needAcceptHeader) {
+		https_opts.headers["Accept"] = "application/vnd.urbanairship+json; version=3;";
+	}
+
 	// We don't necessarily send data
 	if (request_data instanceof Function) {
 		callback = request_data;
 		request_data = null;
 	}
-	
+
 	// Set a Content-Type and Content-Length header if we are sending data
 	if (request_data) {
 		rd = JSON.stringify(request_data);
-		
+
 		https_opts.headers["Content-Type"] = "application/json";
 		https_opts.headers["Content-Length"] = Buffer.byteLength(rd, "utf8");
-	}
-	else {
+	} else {
 		https_opts.headers["Content-Length"] = 0;
 	}
-	
-	var request = https.request(https_opts, function(response) {
+
+	var request = https.request(https_opts, function (response) {
 		response.setEncoding("utf8");
-		
-		response.on("data", function(chunk) {
+
+		response.on("data", function (chunk) {
 			response_data += chunk;
 		});
-		
-		response.on("end", function() {
+
+		response.on("end", function () {
 			// You probably forget the trailing '/'
 			if ((response.statusCode == 301 || response.statusCode == 302) && response.headers && response.headers.location) {
 				var url = require("url"),
 					parsed_url = url.parse(response.headers.location);
-					
-				self._transport(parsed_url.pathname + (parsed_url.search || ""), method, request_data, callback);
+
+				self._transport(parsed_url.pathname + (parsed_url.search || ""), method, request_data, needAcceptHeader, callback);
 			}
 			// Success on 200 or 204, 201 on new device registration
-			else if ([200,201,202,204].indexOf(response.statusCode) >= 0) {
+			else if ([200, 201, 202, 204].indexOf(response.statusCode) >= 0) {
 				try {
 					switch (true) {
-						case /application\/json/.test(response.headers["content-type"]):
-							callback(null, JSON.parse(response_data));
-							break;
-						default:
-							callback(null, response_data);
+					case /application\/json/.test(response.headers["content-type"]):
+						callback(null, JSON.parse(response_data));
+						break;
+					default:
+						callback(null, response_data);
 					}
-				}
-				catch (ex) {
+				} catch (ex) {
 					callback(ex);
 				}
-			}
-			else {
+			} else {
 				callback(new Error(response_data));
 			}
 		});
-		
-		response.on("error", function(error) {
+
+		response.on("error", function (error) {
 			callback(error);
 		});
 	});
-	
-	request.on("error", function(error) {
+
+	request.on("error", function (error) {
 		callback(error);
 	});
-	
+
 	if (request_data) {
 		request.write(rd);
 	}
-	
+
 	request.end();
 };
 


### PR DESCRIPTION
changing _transport fun. prototype.
update all the basics call to follow the new _transport fun. prototype
add new API calls: getSegments, addSegment, getTags, addTag, addTagToDevices, removeTagFromDevices, and updateDevicesTags
